### PR TITLE
bencher: Add config with regression and improvement thresholds.

### DIFF
--- a/.bencher/config.yaml
+++ b/.bencher/config.yaml
@@ -1,0 +1,3 @@
+global:
+  reg_min: 12
+  imp_min: -6

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 
 func main() {
 	resp := commands.Execute(os.Args[1:])
-
+	// dummy change
 	if resp.Err != nil {
 		if resp.IsUserError() {
 			resp.Cmd.Println("")


### PR DESCRIPTION
This change configures bencher to consider changes with a decrease in performance of more than 12% to be a regression and changes with an increase in performance of more than 5% to be an improvement. This will help avoid normal variations in benchmarks from causing the check to fail.

More information on how to configure bencher can be found at https://bencher.orijtech.com/configuration/ . These thresholds can be set at a per-benchmark, per-directory, or global (like this change) level. Also, if you don't want regressions to cause the check to fail, you can set `suppress_failure_on_regression` to false in this configuration file.